### PR TITLE
Fix Microsoft Azure range URL

### DIFF
--- a/cmd/generate-index/input.yaml
+++ b/cmd/generate-index/input.yaml
@@ -40,4 +40,4 @@ cloud:
     oracle:
       - https://docs.oracle.com/en-us/iaas/tools/public_ip_ranges.json
     azure:
-      - https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20221017.json
+      - https://download.microsoft.com/download/7/1/D/71D86715-5596-4529-9B13-DA13A5DE5B63/ServiceTags_Public_20221128.json


### PR DESCRIPTION
This PR changes the URL to fetch the Azure IP ranges.

Close https://github.com/projectdiscovery/cdncheck/issues/52