### PR TITLE
Fix automated release

### DIFF
--- a/.github/workflows/autorelease-tag.yml
+++ b/.github/workflows/autorelease-tag.yml
@@ -24,13 +24,13 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PDTEAMX_PAT }}
           
       - name: Create a GitHub release
         if: ${{ steps.get_commit.outputs.COMMIT_COUNT > 0  }}
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PDTEAMX_PAT }}
         with:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
           release_name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -27,7 +27,7 @@ jobs:
           version: latest
           workdir: .
         env: 
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PDTEAMX_PAT }}"
           SLACK_WEBHOOK: "${{ secrets.RELEASE_SLACK_WEBHOOK }}"
           DISCORD_WEBHOOK_ID: "${{ secrets.DISCORD_WEBHOOK_ID }}"
           DISCORD_WEBHOOK_TOKEN: "${{ secrets.DISCORD_WEBHOOK_TOKEN }}"


### PR DESCRIPTION
This PR fixes the automated release issue, as mentioned in #115. Closes #103. To address this issue, we have switched to using PAT as [suggested in the discussions](https://github.com/orgs/community/discussions/27028) instead of GITHUB_TOKEN.