### PR TITLE
Fix autorelease-tag workflow version bumps

### DIFF
--- a/.github/workflows/autorelease-tag.yml
+++ b/.github/workflows/autorelease-tag.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tag:
+  bump-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,13 +19,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
-      
+
       - name: Bump version in banner.go
         working-directory: internal/runner
         run: |
           curl -LO https://raw.githubusercontent.com/projectdiscovery/utils/main/scripts/versionbump/versionbump.go
           go run versionbump.go -file banner.go -var version -part patch
-      
+
       - name: Create local changes
         working-directory: internal/runner
         run: |
@@ -44,6 +44,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
 
+  tag-release:
+    runs-on: ubuntu-latest
+    needs: bump-version
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Get Commit Count
         id: get_commit
         run: git rev-list  `git rev-list --tags --no-walk --max-count=1`..HEAD --count | xargs -I {} echo COMMIT_COUNT={} >> $GITHUB_OUTPUT
@@ -54,7 +62,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.PDTEAMX_PAT }}
-          
+
       - name: Create a GitHub release
         if: ${{ steps.get_commit.outputs.COMMIT_COUNT > 0  }}
         uses: actions/create-release@v1


### PR DESCRIPTION
As described in https://github.com/projectdiscovery/cdncheck/issues/311#issuecomment-2661215076, the `cdncheck` version is bumped in `banner.go` only after the corresponding tag and release are created. I suspect this might be due to the release steps in the workflow not waiting for the version commit to be pushed before creating the tag and release.

This PR attempts to fix the workflow by splitting out the steps into two separate jobs, where the tag and release job requires the bump version job to be completed before it is run. Hopefully this fixes the issue, but unfortunately there's no real way for me to test it.

(Hopefully: this PR closes #311.)