### PR TITLE
Fix azure source fetch logic + Remove stackpath

### DIFF
--- a/cmd/generate-index/provider.yaml
+++ b/cmd/generate-index/provider.yaml
@@ -18,8 +18,6 @@ cdn:
       - https://api.fastly.com/public-ip-list
     google:
       - https://www.gstatic.com/ipranges/goog.json
-    stackpath:
-      - https://k3t9x2h3.map2.ssl.hwcdn.net/ipblocks.txt
     gocache:
       - https://gocache.com.br/ips
   cidr:

--- a/generate/input.go
+++ b/generate/input.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/ipinfo/go/v2/ipinfo"
@@ -144,7 +145,7 @@ retry:
 		return nil, err
 	}
 	// if the body type is HTML, retry with the first json link in the page (special case for Azure download page to find changing URLs)
-	if resp.Header.Get("Content-Type") == "text/html" && !retried {
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/html") && !retried {
 		var extractedURL string
 		docReader, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
 		if err != nil {


### PR DESCRIPTION
Azure responds with with text/html;charset=utf-8 which fails when checking for an exact match to "text/html" + stackpath has closed down