### PR TITLE
Better connectivity check for DefaultResolvers

### DIFF
--- a/cdncheck.go
+++ b/cdncheck.go
@@ -69,6 +69,7 @@ func availableIpVersions() (hasV6 bool, hasV4 bool) {
 
 	wg.Add(1)
 	go func(){
+		defer wg.Done()
 		if checkConnectivity(IPv6Resolvers, "udp") {
 			hasV6 = true
 		}
@@ -76,6 +77,7 @@ func availableIpVersions() (hasV6 bool, hasV4 bool) {
 
 	wg.Add(1)
 	go func(){
+		defer wg.Done()
 		if checkConnectivity(IPv4Resolvers, "udp") {
 			hasV4 = true
 		}

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -31,7 +31,7 @@ var IPv6Resolvers = []string{
 	"[2001:4860:4860::8844]:53",
 }
 
-// checkConnectivity tests if connectivity is available
+// checkConnectivity tests if connectivity is available to any of the IPs you input
 //
 // - IPs: IPs and ports (e.g. "[2001:db8::1]:53")
 //

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -48,11 +48,11 @@ func checkConnectivity(IPs []string, proto string) bool {
 			defer wg.Done()
 
 			conn, err := net.DialTimeout(proto, IP, 3*time.Second)
+			if conn != nil {
+				defer conn.Close()
+			}
 
 			results <- err == nil
-			if conn != nil {
-				conn.Close()
-			}
 		}()
 	}
 	wg.Wait()

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -31,19 +31,21 @@ var IPv6Resolvers = []string{
 	"[2001:4860:4860::8844]:53",
 }
 
-// checkIPv6Connectivity tests if IPv6 connectivity is available
-func checkIPv6Connectivity() bool {
-	// Test with a well-known IPv6 DNS server
+// checkConnectivity tests if connectivity is available
+//
+// - IPs: IPs and ports (e.g. "[2001:db8::1]:53")
+//
+// - proto: protocol to use (e.g. "udp", "tcp", etc)
+func checkConnectivity(IPs []string, proto string) bool {
 	var wg sync.WaitGroup
-	testResolvers := IPv6Resolvers
-	results := make(chan bool, len(testResolvers))
+	results := make(chan bool, len(IPs))
 
-	for _, resolver := range testResolvers {
+	for _, IP := range IPs {
 		wg.Add(1)
 		go func(){
 			defer wg.Done()
 
-			conn, err := net.DialTimeout("udp", resolver, 3*time.Second)
+			conn, err := net.DialTimeout(proto, IP, 3*time.Second)
 
 			results <- err == nil
 			if conn != nil {
@@ -62,7 +64,7 @@ func checkIPv6Connectivity() bool {
 
 // init checks for IPv6 connectivity and adds IPv6 resolvers if available
 func init() {
-	if checkIPv6Connectivity() {
+	if checkConnectivity(IPv6Resolvers, "udp") {
 		DefaultResolvers = append(DefaultResolvers, IPv6Resolvers...)
 	}
 }

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -15,7 +15,6 @@ var (
 	DefaultCloudProviders string
 )
 
-// DefaultResolvers trusted
 var DefaultResolvers []string
 
 // IPv6Resolvers trusted IPv6 resolvers

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -87,7 +87,7 @@ func availableIpVersions() (hasV6 bool, hasV4 bool) {
 }
 
 
-// init checks for IPv6 connectivity and adds IPv6 resolvers if available
+// init checks for IPv6 and IPv4 connectivity and adds either group of resolvers if available, falls back to both if it can't detect any
 func init() {
 	hasV6, hasV4 := availableIpVersions()
 

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -18,19 +18,20 @@ var (
 // DefaultResolvers trusted
 var DefaultResolvers []string
 
-var IPv4Resolvers = []string{
-	"1.1.1.1:53",
-	"1.0.0.1:53",
-	"8.8.8.8:53",
-	"8.8.4.4:53",
-}
-
 // IPv6Resolvers trusted IPv6 resolvers
 var IPv6Resolvers = []string{
 	"[2606:4700:4700::1111]:53",
 	"[2606:4700:4700::1001]:53",
 	"[2001:4860:4860::8888]:53",
 	"[2001:4860:4860::8844]:53",
+}
+
+// IPv4Resolvers trusted IPv4 resolvers
+var IPv4Resolvers = []string{
+	"1.1.1.1:53",
+	"1.0.0.1:53",
+	"8.8.8.8:53",
+	"8.8.4.4:53",
 }
 
 // checkConnectivity tests if connectivity is available to any of the IPs you input

--- a/cdncheck.go
+++ b/cdncheck.go
@@ -58,8 +58,8 @@ func checkConnectivity(IPs []string, proto string) bool {
 	wg.Wait()
 	close(results)
 
-	for re := range results {
-		if re == true { return true }
+	for result := range results {
+		if result == true { return true }
 	}
 	return false
 }

--- a/cdncheck_test.go
+++ b/cdncheck_test.go
@@ -32,6 +32,21 @@ func TestCDNCheckValid(t *testing.T) {
 }
 
 
-func TestIPv6ConnCheckValid(t *testing.T) {
+func TestConnCheckValid(t *testing.T) {
+	require.True(
+		t,
+		checkConnectivity(DefaultResolvers, "udp"),
+		"DefaultResolvers is showing no connectivity",
+	)
 
+	require.False(
+		t,
+		checkConnectivity([]string{
+			"[::]:0",
+			"[::]:53",
+			"[::]:5",
+			"[::]:10",
+		}, "tcp"),
+		"invalid IPs showing as having connectivity",
+	)
 }

--- a/cdncheck_test.go
+++ b/cdncheck_test.go
@@ -30,3 +30,8 @@ func TestCDNCheckValid(t *testing.T) {
 	require.Nil(t, err, "Could not check ip in ranger")
 	require.False(t, found, "Localhost IP found in blacklist")
 }
+
+
+func TestIPv6ConnCheckValid(t *testing.T) {
+
+}


### PR DESCRIPTION
this PR makes it check all resolvers at the same time for connectivity for both IPv6 and IPv4 and falls back to both if neither is detected instead of just checking Google DNS for only IPv6.