### PR TITLE
keep per-provider data on partial failures and surface errors in fingerprint generation

### DIFF
--- a/.github/workflows/fingerprint-update.yml
+++ b/.github/workflows/fingerprint-update.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
 
@@ -24,6 +24,12 @@ jobs:
           IPINFO_TOKEN: "${{ secrets.IPINFO_TOKEN }}"
         run: go run . -output ../../sources_data.json
         working-directory: cmd/generate-index
+
+      - name: Validate generated sources_data.json
+        run: |
+          # Fail fast if any top-level category dropped to zero providers, which
+          # would indicate a silent regression from an upstream/data fetch issue.
+          jq -e '(.cdn|length) > 0 and (.waf|length) > 0 and (.cloud|length) > 0 and (.common|length) > 0' sources_data.json > /dev/null
 
       - name: Create local changes
         run: |

--- a/cmd/generate-index/main.go
+++ b/cmd/generate-index/main.go
@@ -18,6 +18,7 @@ var (
 	input  = flag.String("input", "provider.yaml", "provider file for processing")
 	output = flag.String("output", "sources_data.json", "output file for generated sources")
 	token  = flag.String("token", "", "Token for the ipinfo service")
+	strict = flag.Bool("strict", true, "exit non-zero if any provider source failed (set to false to keep legacy lenient behaviour)")
 )
 
 func main() {
@@ -40,9 +41,9 @@ func process() error {
 		return err
 	}
 
-	compiled, err := categories.Compile(options)
-	if err != nil {
-		return err
+	compiled, compileErr := categories.Compile(options)
+	if compileErr != nil {
+		log.Printf("[warn] one or more provider sources failed: %s", compileErr)
 	}
 
 	outputFile, err := os.Create(*output)
@@ -87,6 +88,9 @@ func process() error {
 	_, err = outputFile.Write(jsonData)
 	if err != nil {
 		return errors.Wrap(err, "could not write to output file")
+	}
+	if *strict && compileErr != nil {
+		return errors.Wrap(compileErr, "provider source failures (use -strict=false to ignore)")
 	}
 	return nil
 }

--- a/generate/cidrs.go
+++ b/generate/cidrs.go
@@ -1,0 +1,22 @@
+package generate
+
+// appendUniqueCIDRs merges cidrs into existing, preserving order and
+// dropping duplicates already present in either slice.
+func appendUniqueCIDRs(existing, cidrs []string) []string {
+	if len(cidrs) == 0 {
+		return existing
+	}
+	seen := make(map[string]struct{}, len(existing)+len(cidrs))
+	for _, cidr := range existing {
+		seen[cidr] = struct{}{}
+	}
+	out := append([]string(nil), existing...)
+	for _, cidr := range cidrs {
+		if _, ok := seen[cidr]; ok {
+			continue
+		}
+		seen[cidr] = struct{}{}
+		out = append(out, cidr)
+	}
+	return out
+}

--- a/generate/cidrs_test.go
+++ b/generate/cidrs_test.go
@@ -1,0 +1,48 @@
+package generate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendUniqueCIDRs(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		incoming []string
+		want     []string
+	}{
+		{
+			name:     "merge disjoint",
+			existing: []string{"10.0.0.0/24"},
+			incoming: []string{"10.0.1.0/24", "2001:db8::/32"},
+			want:     []string{"10.0.0.0/24", "10.0.1.0/24", "2001:db8::/32"},
+		},
+		{
+			name:     "dedupe overlap",
+			existing: []string{"10.0.0.0/24", "10.0.1.0/24"},
+			incoming: []string{"10.0.1.0/24", "10.0.2.0/24"},
+			want:     []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"},
+		},
+		{
+			name:     "nil existing",
+			existing: nil,
+			incoming: []string{"10.0.0.0/24", "10.0.0.0/24"},
+			want:     []string{"10.0.0.0/24"},
+		},
+		{
+			name:     "empty incoming preserves existing identity",
+			existing: []string{"10.0.0.0/24"},
+			incoming: nil,
+			want:     []string{"10.0.0.0/24"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendUniqueCIDRs(tt.existing, tt.incoming)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/generate/input.go
+++ b/generate/input.go
@@ -33,7 +33,11 @@ func getValidateCidrs(cidrs []string) []string {
 	return output
 }
 
-// Compile returns the compiled form of an input structure
+// Compile returns the compiled form of an input structure.
+//
+// Per-provider/per-source failures are accumulated and returned as a joined
+// error. The compiled result is still returned alongside the error so callers
+// can decide whether to use a partially populated dataset.
 func (c *Categories) Compile(options *Options) (*cdncheck.InputCompiled, error) {
 	compiled := &cdncheck.InputCompiled{
 		CDN:    make(map[string][]string),
@@ -41,20 +45,23 @@ func (c *Categories) Compile(options *Options) (*cdncheck.InputCompiled, error) 
 		Cloud:  make(map[string][]string),
 		Common: make(map[string][]string),
 	}
-	// Fetch input items specified
+	var errs []error
 	if c.CDN != nil {
 		if err := c.CDN.fetchInputItem(options, compiled.CDN); err != nil {
-			log.Printf("[err] could not fetch cdn item: %s\n", err)
+			log.Printf("[err] cdn: %s\n", err)
+			errs = append(errs, fmt.Errorf("cdn: %w", err))
 		}
 	}
 	if c.WAF != nil {
 		if err := c.WAF.fetchInputItem(options, compiled.WAF); err != nil {
-			log.Printf("[err] could not fetch waf item: %s\n", err)
+			log.Printf("[err] waf: %s\n", err)
+			errs = append(errs, fmt.Errorf("waf: %w", err))
 		}
 	}
 	if c.Cloud != nil {
 		if err := c.Cloud.fetchInputItem(options, compiled.Cloud); err != nil {
-			log.Printf("[err] could not fetch cloud item: %s\n", err)
+			log.Printf("[err] cloud: %s\n", err)
+			errs = append(errs, fmt.Errorf("cloud: %w", err))
 		}
 	}
 	if c.Common != nil {
@@ -77,43 +84,53 @@ func (c *Categories) Compile(options *Options) (*cdncheck.InputCompiled, error) 
 		}
 		for _, item := range scraper {
 			if response, err := item.scraper(http.DefaultClient); err != nil {
-				log.Printf("[err] could not scrape %s item: %s\n", item.name, err)
+				log.Printf("[err] scraper %s/%s: %s\n", dataType, item.name, err)
+				errs = append(errs, fmt.Errorf("scraper %s/%s: %w", dataType, item.name, err))
 			} else {
-				data[item.name] = response
+				data[item.name] = appendUniqueCIDRs(data[item.name], response)
 			}
 		}
 	}
-	return compiled, nil
+	return compiled, errors.Join(errs...)
 }
 
-// fetchInputItem fetches input items and writes data to map
+// fetchInputItem fetches input items and writes data to map.
+//
+// On per-item failure the loop continues so a single unreachable URL or ASN
+// does not drop the rest of the providers in this category. All errors are
+// joined and returned at the end. Multiple URLs/ASNs declared for the same
+// provider are merged (deduped) instead of overwritten.
 func (c *Category) fetchInputItem(options *Options, data map[string][]string) error {
+	var errs []error
 	for provider, cidrs := range c.CIDR {
-		data[provider] = cidrs
+		data[provider] = appendUniqueCIDRs(data[provider], cidrs)
 	}
 	for provider, urls := range c.URLs {
 		for _, item := range urls {
-			if cidrs, err := getCIDRFromURL(item); err != nil {
-				return fmt.Errorf("could not get url %s: %s", item, err)
-			} else {
-				data[provider] = cidrs
+			cidrs, err := getCIDRFromURL(item)
+			if err != nil {
+				log.Printf("[err] url %s (%s): %s\n", provider, item, err)
+				errs = append(errs, fmt.Errorf("url %s (%s): %w", provider, item, err))
+				continue
 			}
+			data[provider] = appendUniqueCIDRs(data[provider], cidrs)
 		}
 	}
-	// Only scrape ASN if we have an ID
 	if !options.HasAuthInfo() {
-		return nil
+		return errors.Join(errs...)
 	}
 	for provider, asn := range c.ASN {
 		for _, item := range asn {
-			if cidrs, err := getIpInfoASN(http.DefaultClient, options.IPInfoToken, item); err != nil {
-				return fmt.Errorf("could not get asn %s: %s", item, err)
-			} else {
-				data[provider] = cidrs
+			cidrs, err := getIpInfoASN(http.DefaultClient, options.IPInfoToken, item)
+			if err != nil {
+				log.Printf("[err] asn %s (%s): %s\n", provider, item, err)
+				errs = append(errs, fmt.Errorf("asn %s (%s): %w", provider, item, err))
+				continue
 			}
+			data[provider] = appendUniqueCIDRs(data[provider], cidrs)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 var errNoCidrFound = errors.New("no cidrs found for url")
@@ -133,6 +150,9 @@ func getIpInfoASN(httpClient *http.Client, token string, asn string) ([]string, 
 	}
 	var cidrs []string
 	for _, prefix := range info.Prefixes {
+		cidrs = append(cidrs, prefix.Netblock)
+	}
+	for _, prefix := range info.Prefixes6 {
 		cidrs = append(cidrs, prefix.Netblock)
 	}
 	if len(cidrs) == 0 {

--- a/generate/input_test.go
+++ b/generate/input_test.go
@@ -1,0 +1,134 @@
+package generate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestFetchInputItem_MergesMultipleURLsPerProvider(t *testing.T) {
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("10.0.0.0/24\n10.0.1.0/24\n"))
+	}))
+	defer srv1.Close()
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("10.0.1.0/24\n10.0.2.0/24\n"))
+	}))
+	defer srv2.Close()
+
+	cat := &Category{
+		URLs: map[string][]string{
+			"provider": {srv1.URL, srv2.URL},
+		},
+	}
+	data := map[string][]string{}
+	if err := cat.fetchInputItem(&Options{}, data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := append([]string(nil), data["provider"]...)
+	sort.Strings(got)
+	want := []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"}
+	if !equalStrings(got, want) {
+		t.Fatalf("merged cidrs = %v, want %v", got, want)
+	}
+}
+
+func TestFetchInputItem_ContinuesOnURLError(t *testing.T) {
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("10.0.0.0/24\n"))
+	}))
+	defer good.Close()
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	bad.Close() // force connection refused for predictable failure
+
+	cat := &Category{
+		URLs: map[string][]string{
+			"ok":      {good.URL},
+			"failing": {bad.URL},
+		},
+	}
+	data := map[string][]string{}
+	err := cat.fetchInputItem(&Options{}, data)
+	if err == nil {
+		t.Fatalf("expected error for failing provider")
+	}
+	if !strings.Contains(err.Error(), "failing") {
+		t.Fatalf("error should reference failing provider, got %q", err.Error())
+	}
+	if got := data["ok"]; len(got) != 1 || got[0] != "10.0.0.0/24" {
+		t.Fatalf("ok provider data = %v, want [10.0.0.0/24]", got)
+	}
+	if _, exists := data["failing"]; exists {
+		t.Fatalf("failing provider should not have populated data, got %v", data["failing"])
+	}
+}
+
+func TestFetchInputItem_StaticCIDRsMergedWithURLs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("10.0.1.0/24\n"))
+	}))
+	defer srv.Close()
+
+	cat := &Category{
+		CIDR: map[string][]string{
+			"provider": {"10.0.0.0/24"},
+		},
+		URLs: map[string][]string{
+			"provider": {srv.URL},
+		},
+	}
+	data := map[string][]string{}
+	if err := cat.fetchInputItem(&Options{}, data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := append([]string(nil), data["provider"]...)
+	sort.Strings(got)
+	want := []string{"10.0.0.0/24", "10.0.1.0/24"}
+	if !equalStrings(got, want) {
+		t.Fatalf("merged cidrs = %v, want %v", got, want)
+	}
+}
+
+func TestFetchInputItem_NoAuthSkipsASNNotURLs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("10.0.0.0/24\n"))
+	}))
+	defer srv.Close()
+
+	cat := &Category{
+		URLs: map[string][]string{
+			"provider": {srv.URL},
+		},
+		ASN: map[string][]string{
+			"asn-only": {"AS12345"},
+		},
+	}
+	data := map[string][]string{}
+	if err := cat.fetchInputItem(&Options{}, data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data["provider"]) != 1 {
+		t.Fatalf("expected URL provider populated when no token, got %v", data["provider"])
+	}
+	if _, ok := data["asn-only"]; ok {
+		t.Fatalf("ASN-only provider should be skipped when no token, got %v", data["asn-only"])
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- `generate.Compile` / `Category.fetchInputItem` no longer abort an entire category on the first failing URL or ASN. Per-source errors are accumulated and joined.
- Multiple URLs or ASNs declared for the same provider are now merged (deduped) instead of overwritten.
- `getIpInfoASN` now includes IPv6 prefixes (`Prefixes6`).
- `cmd/generate-index` gains a `-strict` flag (default `true`) so a failing provider source surfaces as a non-zero exit, instead of silently producing an incomplete `sources_data.json`.
- `Fingerprint Update` workflow bumps `actions/checkout@v4` and `actions/setup-go@v5`, and adds a `jq -e` guard that fails the run if any top-level category collapses to zero providers.

This was triggered by silent data loss in recent runs (e.g. WAF Akamai disappearing from `sources_data.json` after ipinfo started returning 401 for the first ASN of the category).

Closes #375

## Test plan

- [x] ``go test ./...``
- [x] ``go vet ./...``
- [x] New unit tests cover: merge of multiple URLs per provider, continue-on-error with one failing URL, static CIDR + URL merge, ASN skipped without auth while URL still fetched.
- [ ] Manual rerun of ``Fingerprint Update`` after merge + token rotation to confirm Akamai/Sucuri/Leaseweb repopulate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-strict` flag to control provider source compilation failure behavior; when disabled, generation continues with available data despite failures.
  * Improved data merging from multiple provider sources with automatic deduplication.

* **Bug Fixes**
  * Enhanced compilation error handling to accumulate errors and continue processing instead of stopping on the first failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/cdncheck/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->